### PR TITLE
On systemd, we don't need '--die-on-term'

### DIFF
--- a/templates/uwsgi_systemd.service.erb
+++ b/templates/uwsgi_systemd.service.erb
@@ -8,7 +8,7 @@ Description=uWSGI Emperor
 After=syslog.target
 
 [Service]
-ExecStart=<%= @binary_directory %>/uwsgi --die-on-term --ini <%= @config_file %>
+ExecStart=<%= @binary_directory %>/uwsgi --ini <%= @config_file %>
 # Requires systemd version 211 or newer
 RuntimeDirectory=uwsgi
 Restart=always


### PR DESCRIPTION
When deployed on a recent (Apr 2017) Ubuntu 16.04 release, the `--die-on-term` directive on the systemd service file causes extremely slow stop/start cycles.

Since we are already telling systemd to use `SIGQUIT` for the KillSignal, there is no need to use `--die-on-term`, as that would reverse `SIGQUIT` and `SIGKILL` interpretation in uWSGI.

Fixes https://github.com/rvdh/puppet-uwsgi/issues/21